### PR TITLE
retain `fixed_position` during reset-nodedb

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -558,7 +558,8 @@ void NodeDB::installDefaultChannels()
 
 void NodeDB::resetNodes()
 {
-    clearLocalPosition();
+    if (!config.position.fixed_position)
+        clearLocalPosition();
     numMeshNodes = 1;
     std::fill(devicestate.node_db_lite.begin() + 1, devicestate.node_db_lite.end(), meshtastic_NodeInfoLite());
     devicestate.has_rx_text_message = false;


### PR DESCRIPTION
test